### PR TITLE
Try to avoid try/catch assertions with JUnit @Rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,32 +43,38 @@
     </distributionManagement>
     <properties>
         <java.version>1.8</java.version>
-        <maven-gpg-plugin.version />
         <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
         <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
         <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
         <spring.version>4.3.15.RELEASE</spring.version>
+        <spring-boot.version>1.5.10.RELEASE</spring-boot.version>
+        <hamcrest-all.version>1.3</hamcrest-all.version>
+        <aspectjweaver.version>1.8.8</aspectjweaver.version>
+        <validation-api.version>1.1.0.Final</validation-api.version>
+        <el-api.version>2.2</el-api.version>
+        <el-impl.version>2.2</el-impl.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <version>1.8.8</version>
+            <version>${aspectjweaver.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>1.1.0.Final</version>
+            <version>${validation-api.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>el-api</artifactId>
-            <version>2.2</version>
+            <version>${el-api.version}</version>
         </dependency>
+        
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
@@ -81,23 +87,29 @@
             <version>${spring.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>${hamcrest-all.version}</version>
+            <scope>compile</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>1.5.10.RELEASE</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>1.5.10.RELEASE</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>el-impl</artifactId>
-            <version>2.2</version>
+            <version>${el-impl.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/opensanca/matchers/ServiceValidatorErrorMatcher.java
+++ b/src/main/java/io/github/opensanca/matchers/ServiceValidatorErrorMatcher.java
@@ -1,0 +1,31 @@
+package io.github.opensanca.matchers;
+
+import io.github.opensanca.exception.ServiceValidationErrorCollection;
+import io.github.opensanca.exception.ServiceValidationException;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public class ServiceValidatorErrorMatcher extends TypeSafeMatcher<ServiceValidationException> {
+
+    private Integer expectedSize;
+    private ServiceValidationErrorCollection errors;
+
+    public ServiceValidatorErrorMatcher(final Integer expectedSize) {
+        this.expectedSize = expectedSize;
+    }
+
+    public static ServiceValidatorErrorMatcher errorCollectionHasSize(final Integer expectedSize) {
+        return new ServiceValidatorErrorMatcher(expectedSize);
+    }
+
+    @Override
+    protected boolean matchesSafely(final ServiceValidationException e) {
+        errors = e.getErrors();
+        return errors.size() == expectedSize;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendValue(expectedSize).appendText(" was not found instead of ").appendValue(errors.size());
+    }
+}

--- a/src/main/java/io/github/opensanca/matchers/ServiceValidatorViolationsMatcher.java
+++ b/src/main/java/io/github/opensanca/matchers/ServiceValidatorViolationsMatcher.java
@@ -1,0 +1,51 @@
+package io.github.opensanca.matchers;
+
+import java.util.List;
+
+import io.github.opensanca.exception.ServiceValidationException;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.springframework.util.CollectionUtils;
+
+public class ServiceValidatorViolationsMatcher extends TypeSafeMatcher<ServiceValidationException> {
+
+    private String key;
+    private String value;
+    private List<String> constraints;
+    private boolean hasErrorKey;
+    private boolean hasErrorValue;
+
+    public ServiceValidatorViolationsMatcher(final String key, final String value) {
+        this.key = key;
+        this.value = value;
+        this.hasErrorKey = false;
+        this.hasErrorValue = false;
+    }
+
+    public static ServiceValidatorViolationsMatcher errorCollectionHasViolation(final String key, final String value) {
+        return new ServiceValidatorViolationsMatcher(key, value);
+    }
+
+    @Override
+    protected boolean matchesSafely(final ServiceValidationException e) {
+        constraints = e.getErrors().get(key);
+        if (CollectionUtils.isEmpty(constraints)) {
+            hasErrorKey = true;
+            return false;
+        } else {
+            final boolean isValidationOk = constraints.contains(value);
+            hasErrorValue = !isValidationOk;
+            return isValidationOk;
+        }
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        if (hasErrorKey) {
+            description.appendValue(key.toString()).appendText(" key not found.");
+        }
+        if (hasErrorValue) {
+            description.appendText("Found ").appendValue(constraints).appendText(" instead of ").appendValue(value);
+        }
+    }
+}

--- a/src/test/java/io/github/opensanca/DemoSpringBootWebApp.java
+++ b/src/test/java/io/github/opensanca/DemoSpringBootWebApp.java
@@ -1,9 +1,11 @@
 package io.github.opensanca;
 
+import java.util.Locale;
+
 import javax.validation.constraints.NotNull;
 
 import io.github.opensanca.annotation.ServiceValidation;
-import java.util.Locale;
+import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -29,6 +31,7 @@ public class DemoSpringBootWebApp implements ApplicationListener<ApplicationRead
 class DTO {
 
     @NotNull
+    @NotEmpty
     private String text;
 
     public void setText(String text) {


### PR DESCRIPTION
Ref to issue #1 .

To avoid try/catch exception, I propose to use JUnit Rules. So, I add some news Matchers of Hamcrest:

```
new file:   src/test/java/io/github/opensanca/matchers/ServiceValidatorErrorMatcher.java
new file:   src/test/java/io/github/opensanca/matchers/ServiceValidatorViolationsMatcher.java
```

```
@Rule
public ExpectedException exception = ExpectedException.none();
```

```
 @Test
  public void shouldValidateJavax() {
        exception.expect(ServiceValidationException.class);
        exception.expect(ServiceValidatorErrorMatcher.hasSize(1));
        exception.expect(ServiceValidatorViolationsMatcher.hasViolation("DTO.text", "may not be null"));
        exception.expect(ServiceValidatorViolationsMatcher.hasViolation("DTO.text", "may not be empty"));

        component.defaultValidation(new DTO());
  }
```

